### PR TITLE
docs: fix README content issues

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![Build](https://github.com/ballerina-platform/module-ballerinax-hubspot.crm.lists/actions/workflows/ci.yml/badge.svg)](https://github.com/ballerina-platform/module-ballerinax-hubspot.crm.lists/actions/workflows/ci.yml)
 [![GitHub Last Commit](https://img.shields.io/github/last-commit/ballerina-platform/module-ballerinax-hubspot.crm.lists.svg)](https://github.com/ballerina-platform/module-ballerinax-hubspot.crm.lists/commits/master)
-[![GitHub Issues](https://img.shields.io/github/issues/ballerina-platform/ballerina-library/module/hubspot.crm.lists.svg?label=Open%20Issues)](https://github.com/ballerina-platform/ballerina-library/labels/module%hubspot.crm.lists)
+[![GitHub Issues](https://img.shields.io/github/issues/ballerina-platform/ballerina-library/module/hubspot.crm.lists.svg?label=Open%20Issues)](https://github.com/ballerina-platform/ballerina-library/labels/module%2Fhubspot.crm.lists)
 
 ## Overview
 


### PR DESCRIPTION
## Purpose

Fix documentation issues identified in the HubSpot connector revamp audit.

- Fix the encoding bug in the GitHub Issues badge link URL: `module%hubspot.crm.lists` -> `module%2Fhubspot.crm.lists`.

The other systemic fixes from the audit do not apply to this repo:
- No standalone `Hubspot` brand-name occurrences (the only matches are inside image alt-text such as `![Hubspot developer portal](...)`, which the spec excludes).
- No `ave` typo present.
- Title is already in the canonical `# Ballerina HubSpot CRM Lists connector` form.

## Examples

N/A - documentation-only change to `README.md`.

## Checklist
- [x] Linked to an issue (Refs `ballerina-platform/ballerina-library#8823`)
- [ ] Updated the changelog - N/A (docs-only)
- [ ] Added tests - N/A (docs-only)
- [ ] Updated the spec - N/A (docs-only)
- [x] Checked native-image compatibility - N/A (no code change)

Refs ballerina-platform/ballerina-library#8823