### PR TITLE
fix: update release workflow template ref to main

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,7 +9,7 @@ jobs:
   call_workflow:
     name: Run Release Workflow
     if: ${{ github.repository_owner == 'ballerina-platform' }}
-    uses: ballerina-platform/ballerina-library/.github/workflows/release-package-connector-template.yml@2201.10.x
+    uses: ballerina-platform/ballerina-library/.github/workflows/release-package-connector-template.yml@main
     secrets: inherit
     with:
       package-name: hubspot.crm.lists


### PR DESCRIPTION
Updates the release workflow to reference the `main` branch of the connector release template instead of the outdated `2201.10.x` branch.

The `2201.10.x` template pins JDK 17, which is incompatible with `distribution = "2201.12.0"` declared in `Ballerina.toml` — that distribution requires Java 21. The `main` template pins JDK 21 and also includes a missing `git push origin release-${VERSION}` step required before the sync PR is created.